### PR TITLE
Switch to stateless waypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,23 @@ As this is an effect manager and uses native code it isn't available at http://p
 
 ```
 type Msg =
-    WaypointEnteredView String
+    WaypointTriggered String
 
 update msg model =
     case msg of
-        WaypointEnteredView waypointName ->
+        WaypointTriggered message ->
             ...
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Waypoints.enteredView "element1" (WaypointEnteredView "waypoint1")
+    Sub.batch
+        [ Waypoints.enteredTop "element1" (WaypointTigger "element entered top of window")
+        , Waypoints.exitedTop "element1" (WaypointTigger "element exited top of window")
+        , Waypoints.crossedTop "element1" (WaypointTigger "element crossed top of window")
+        , Waypoints.enteredBottom "element1" (WaypointTigger "element entered bottom of window")
+        , Waypoints.exitedBottom "element1" (WaypointTigger "element exited bottom of window")
+        , Waypoints.crossedBottom "element1" (WaypointTigger "elemented crossed bottom of window")
+        ]
 
 
 view : Model -> Html Msg

--- a/examples/MentionsTracker.elm
+++ b/examples/MentionsTracker.elm
@@ -110,7 +110,10 @@ messageElementId messageId =
 subscriptions model =
     let
         messageWaypoint mention =
-            Waypoints.enteredView (messageElementId mention) (MessageRead mention)
+            Sub.batch
+                [ Waypoints.crossedTop (messageElementId mention) (MessageRead mention)
+                , Waypoints.crossedBottom (messageElementId mention) (MessageRead mention)
+                ]
     in
         model.mentions
             |> Set.toList

--- a/examples/WaypointsExample.elm
+++ b/examples/WaypointsExample.elm
@@ -3,6 +3,7 @@ module WaypointsExample exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
+import Set
 import Waypoints
 
 
@@ -87,4 +88,4 @@ subscriptions model =
         elementId =
             "elem" ++ (toString model.currentElement)
     in
-        Waypoints.enteredView elementId (Appeared elementId)
+        Waypoints.crossedTop elementId (Appeared elementId)

--- a/src/Native/DomHelpers.js
+++ b/src/Native/DomHelpers.js
@@ -17,5 +17,12 @@ var _zapnito$elm_waypoints$Native_DomHelpers = {
 
             return function() {};
         });
+    },
+
+    scrollPosition: function() {
+        return {
+            x: document.defaultView.scrollX,
+            y: document.defaultView.scrollY
+        }
     }
 }

--- a/src/Waypoints/Internal/DomHelpers.elm
+++ b/src/Waypoints/Internal/DomHelpers.elm
@@ -1,17 +1,8 @@
-module DomHelpers exposing (getBoundingClientRect, getWindowHeight, BoundingClientRect, waitForRender)
+module Waypoints.Internal.DomHelpers exposing (getBoundingClientRect, getWindowHeight, waitForRender, scrollPosition)
 
 import Native.DomHelpers
 import Json.Decode as JD exposing (Decoder)
-
-
-type alias BoundingClientRect =
-    { top : Float
-    , right : Float
-    , bottom : Float
-    , left : Float
-    , width : Float
-    , height : Float
-    }
+import Waypoints.Internal.Types exposing (Position, BoundingClientRect)
 
 
 getBoundingClientRect : String -> Result String BoundingClientRect
@@ -39,3 +30,8 @@ getWindowHeight =
 waitForRender : () -> Platform.Task x ()
 waitForRender () =
     Native.DomHelpers.waitForRender ()
+
+
+scrollPosition : () -> Position
+scrollPosition () =
+    Native.DomHelpers.scrollPosition ()

--- a/src/Waypoints/Internal/Helpers.elm
+++ b/src/Waypoints/Internal/Helpers.elm
@@ -1,0 +1,49 @@
+module Waypoints.Internal.Helpers exposing (..)
+
+import Waypoints.Internal.Types exposing (..)
+
+
+isWaypointHit : Edge -> Transition -> Float -> Float -> Float -> Bool
+isWaypointHit edge transition previousTop currentTop screenHeight =
+    let
+        topOfScreen =
+            0
+
+        bottomOfScreen =
+            screenHeight
+
+        conditions =
+            case ( transition, edge ) of
+                ( Entered, Top ) ->
+                    [ crossedDown topOfScreen previousTop currentTop ]
+
+                ( Exited, Top ) ->
+                    [ crossedUp topOfScreen previousTop currentTop ]
+
+                ( Crossed, Top ) ->
+                    [ crossedDown topOfScreen previousTop currentTop
+                    , crossedUp topOfScreen previousTop currentTop
+                    ]
+
+                ( Entered, Bottom ) ->
+                    [ crossedUp bottomOfScreen previousTop currentTop ]
+
+                ( Exited, Bottom ) ->
+                    [ crossedDown bottomOfScreen previousTop currentTop ]
+
+                ( Crossed, Bottom ) ->
+                    [ crossedUp bottomOfScreen previousTop currentTop
+                    , crossedDown bottomOfScreen previousTop currentTop
+                    ]
+    in
+        List.any identity conditions
+
+
+crossedDown : Float -> Float -> Float -> Bool
+crossedDown referencePoint previousTop currentTop =
+    previousTop < referencePoint && referencePoint < currentTop
+
+
+crossedUp : Float -> Float -> Float -> Bool
+crossedUp referencePoint previousTop currentTop =
+    previousTop > referencePoint && referencePoint > currentTop

--- a/src/Waypoints/Internal/Types.elm
+++ b/src/Waypoints/Internal/Types.elm
@@ -1,0 +1,28 @@
+module Waypoints.Internal.Types exposing (..)
+
+
+type alias BoundingClientRect =
+    { top : Float
+    , right : Float
+    , bottom : Float
+    , left : Float
+    , width : Float
+    , height : Float
+    }
+
+
+type alias Position =
+    { x : Float
+    , y : Float
+    }
+
+
+type Edge
+    = Top
+    | Bottom
+
+
+type Transition
+    = Entered
+    | Exited
+    | Crossed

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+/elm-stuff/

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,0 +1,13 @@
+port module Main exposing (..)
+
+import Tests
+import Test.Runner.Node exposing (run, TestProgram)
+import Json.Encode exposing (Value)
+
+
+main : TestProgram
+main =
+    run emit Tests.all
+
+
+port emit : ( String, Value ) -> Cmd msg

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,0 +1,12 @@
+module Tests exposing (..)
+
+import Test exposing (..)
+import Expect
+import Waypoints.Internal.HelpersTest
+
+
+all : Test
+all =
+    describe "Waypoints"
+        [ Waypoints.Internal.HelpersTest.all
+        ]

--- a/tests/Waypoints/Internal/HelpersTest.elm
+++ b/tests/Waypoints/Internal/HelpersTest.elm
@@ -1,0 +1,61 @@
+module Waypoints.Internal.HelpersTest exposing (all)
+
+import Test exposing (..)
+import Expect
+import Waypoints.Internal.Helpers
+import Waypoints.Internal.Types exposing (Edge(..), Transition(..))
+
+
+screenHeight =
+    800
+
+
+waypointRectWith =
+    { top = 0
+    , right = 1024
+    , bottom = 800
+    , left = 0
+    , width = 1024
+    , height = 800
+    }
+
+
+all =
+    describe "Internal"
+        [ expectHit Entered Top -50 50 screenHeight
+        , expectNoHit Entered Top 50 -50 screenHeight
+        , expectNoHit Entered Top -40 -50 screenHeight
+        , expectNoHit Exited Top -50 50 screenHeight
+        , expectHit Exited Top 50 -50 screenHeight
+        , expectHit Crossed Top -50 50 screenHeight
+        , expectHit Crossed Top 50 -50 screenHeight
+        , expectNoHit Crossed Top 40 50 screenHeight
+        , expectHit Exited Bottom (screenHeight - 100) (screenHeight + 100) screenHeight
+        , expectNoHit Exited Bottom (screenHeight + 100) (screenHeight - 100) screenHeight
+        , expectHit Entered Bottom (screenHeight + 100) (screenHeight - 100) screenHeight
+        , expectNoHit Entered Bottom (screenHeight - 100) (screenHeight + 100) screenHeight
+        ]
+
+
+expectHit transition edge previousTop currentTop screenHeight =
+    test ("when scroll " ++ (toString previousTop) ++ " => " ++ (toString currentTop)) <|
+        \() ->
+            Expect.true ("should fire: " ++ (toString transition) ++ "/" ++ (toString edge)) <|
+                Waypoints.Internal.Helpers.isWaypointHit
+                    edge
+                    transition
+                    previousTop
+                    currentTop
+                    screenHeight
+
+
+expectNoHit transition edge previousTop currentTop screenHeight =
+    test ("when scroll " ++ (toString previousTop) ++ " => " ++ (toString currentTop)) <|
+        \() ->
+            Expect.false ("should not fire: " ++ (toString transition) ++ "/" ++ (toString edge)) <|
+                Waypoints.Internal.Helpers.isWaypointHit
+                    edge
+                    transition
+                    previousTop
+                    currentTop
+                    screenHeight

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.0.0",
+    "summary": "Sample Elm Test",
+    "repository": "https://github.com/zapnito/elm-waypoints.git",
+    "license": "BSD-3-Clause",
+    "source-directories": [
+        ".",
+        "../src"
+    ],
+    "exposed-modules": [],
+    "native-modules": true,
+    "dependencies": {
+        "elm-community/json-extra": "2.0.0 <= v < 3.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "mgold/elm-random-pcg": "4.0.2 <= v < 5.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
+        "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0",
+        "elm-lang/dom": "1.1.1 <= v < 2.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
Replaced 
• `Waypoints.enteredView` 

with 

• `Waypoints.enteredTop` 
• `Waypoints.exitedTop`
• `Waypoints.crossedTop`
• `Waypoints.enteredBottom` 
• `Waypoints.exitedBottom`
• `Waypoints.crossedBottom`

resolves https://github.com/zapnito/elm-waypoints/issues/1